### PR TITLE
Create tspan instead title in setText function

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -79,20 +79,15 @@ export class Utils {
     textElement: HTMLElement | SVGGraphicsElement,
     text: string
   ): void {
-    const tspanElement = textElement.querySelector('tspan');
-    if (tspanElement) {
-      tspanElement.textContent = text;
-    } else {
-      let titleElement = textElement.querySelector('title') as Element;
-      if (!titleElement) {
-        titleElement = document.createElementNS(
-          'http://www.w3.org/2000/svg',
-          'title'
-        );
-        textElement.appendChild(titleElement);
-      }
-      titleElement.textContent = text;
+    let tspanElement = textElement.querySelector('tspan');
+    if (!tspanElement) {
+      tspanElement = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'tspan'
+      );
+      textElement.appendChild(tspanElement);
     }
+    tspanElement.textContent = text;
   }
 
   static waitForChildNodes(


### PR DESCRIPTION
Currently, the tooltip create a title tag inside the target element.
But the text_set directive create a title element too when there is no tspan in the text element.
This result to a conflict on some SVG without tspan in text elements (like Illustrator made SVG).
This commit make the setText function only works with tspan (update or create tspan element if not exists).

This PR must be carefully reviewed by other contributors cause I don't know enough about the project to know if it can break something elsewhere.