### PR TITLE
The action in one page will affect the elements in the other pages

### DIFF
--- a/src/components/floorplan/floorplan-element.ts
+++ b/src/components/floorplan/floorplan-element.ts
@@ -1801,13 +1801,15 @@ export class FloorplanElement extends LitElement {
 
     if (targetSvgElementIds.length) {
       for (const targetSvgElementId of targetSvgElementIds) {
-        targetSvgElements = targetSvgElements.concat(
-          this._querySelectorAll(
-            this.svg,
-            `#${targetSvgElementId.replace(/\./g, '\\.')}`,
-            false
-          ) as SVGGraphicsElement[]
-        );
+        for (const pageInfo of Object.values(this.pageInfos)) {
+          targetSvgElements = targetSvgElements.concat(
+            this._querySelectorAll(
+              pageInfo.svg,
+              `#${targetSvgElementId.replace(/\./g, '\\.')}`,
+              false
+            ) as SVGGraphicsElement[]
+          );
+        }
       }
     } else if (svgElement) {
       // might be null (i.e. element: null in rule)


### PR DESCRIPTION
Hello, 

There was a problem during the `initStartupActions` when there are multiple `pages` in the floorplan. 

With this update, whatever `floorplan call-service` you do in one page, 
* text_set
* class_set
* style_set
* class_toggle
will have an effect with the rest of pages. 

Also, the `initStartupActions` defined on each page can overwrite the `initStartupActions` defined in other pages (depends on the loading page order). 

Ideally, the `initStartupActions` should have effects only on the page where it is defined. A  parameter extra could be called in the `call-service` in case we want to allow the possibility of having an effect in a set of pages (defined by the page id).
What do you think @exetico ?  

Definitely, what I'm proposing is not the best solution, but at least it fixes the issues partially. Otherwise, the `call-service` cannot be called when multiple pages are defined in the floorplan.