### PR TITLE
Bug fix: last_update last_changed ignore browser locale

### DIFF
--- a/src/components/floorplan/floorplan-element.ts
+++ b/src/components/floorplan/floorplan-element.ts
@@ -1515,12 +1515,8 @@ export class FloorplanElement extends LitElement {
             svgElementInfo.svgElement
               .querySelectorAll('title')
               .forEach((titleElement) => {
-                const lastChangedDate = Utils.formatDate(
-                  entityState.last_changed
-                );
-                const lastUpdatedDate = Utils.formatDate(
-                  entityState.last_updated
-                );
+                const lastChangedDate = entityState.last_changed.toString();
+                const lastUpdatedDate = entityState.last_changed.toString();
 
                 let titleText = `${entityState.attributes.friendly_name}\n`;
                 titleText += `State: ${entityState.state}\n\n`;

--- a/src/components/floorplan/floorplan-element.ts
+++ b/src/components/floorplan/floorplan-element.ts
@@ -1529,14 +1529,23 @@ export class FloorplanElement extends LitElement {
                   }
                 });
                 titleText += '\n';
-
-                titleText += `Last changed: ${DateUtil.timeago(
-                  lastChangedDate
-                )}\n`;
-                titleText += `Last updated: ${DateUtil.timeago(
-                  lastUpdatedDate
-                )}`;
-
+                let language:String = window.navigator.userLanguage || window.navigator.language;
+                if (language.includes('zh')) {
+                  titleText += `上次变化: ${DateUtil.timeago(
+                    lastChangedDate, 'zh_CN'
+                  )}\n`;
+                  titleText += `上次更新: ${DateUtil.timeago(
+                    lastUpdatedDate, 'zh_CN'
+                  )}`;
+                }
+                else {
+                  titleText += `Last changed: ${DateUtil.timeago(
+                    lastChangedDate
+                  )}\n`;
+                  titleText += `Last updated: ${DateUtil.timeago(
+                    lastUpdatedDate
+                  )}`;
+                }
                 titleElement.textContent = titleText;
               });
           }


### PR DESCRIPTION
Timeago.js cannot be applied to date string in languages other than English.
The original string used in last_update and last_changed sent to the timeago.js was Locale dependent which results in unexpected behaviors for browsers with language set to be non English.
This pull request removed the locale awareness and feed timeago.js a string in English regardless of the browser language setting.