### PR TITLE
Evaluate the 'element' option for rules, so it can be used as a template string for an array of entity IDs

### DIFF
--- a/src/components/floorplan/floorplan-element.ts
+++ b/src/components/floorplan/floorplan-element.ts
@@ -1143,7 +1143,9 @@ export class FloorplanElement extends LitElement {
     for (const entityId of entityIds) {
       let elementIds = [] as string[];
       if (rule.elements) elementIds = elementIds.concat(rule.elements);
-      else if (rule.element) elementIds = elementIds.concat(rule.element);
+      else if (rule.element) elementIds = elementIds.concat(
+        this.evaluate(rule.element, entityId, undefined) as string
+      );
       else if (rule.element !== null) elementIds = elementIds.concat(entityId);
       this.addTargetEntity(entityId, elementIds, targetEntities);
     }


### PR DESCRIPTION
#### Discussion: https://github.com/ExperienceLovelace/ha-floorplan/discussions/231

I've just tested this locally and everything works great. I really like that this allows me to organize my SVG IDs and use prefixes that correspond to different rules, like `motion.`, `timer.`, `floor.`, etc.

Here's the ha-floorplan config I'm working on for my garage / workshop area, updated to use this change with element as a JS template: https://gist.github.com/ndbroadbent/df2e20958a9de4365b6f9decc0e75185


* Related: https://github.com/ExperienceLovelace/ha-floorplan/discussions/159
