### PR TITLE
Added a prefixed class set service

### DIFF
--- a/docs/_docs/03-usage.md
+++ b/docs/_docs/03-usage.md
@@ -267,7 +267,7 @@ Below is an example of using JavaScript [template literals](https://developer.mo
         class: '${(entity.state === "on") ? "motion-on" : "motion-off"}'
 ```
 
-Following is an example of using dataset and JavaScript [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) to dynamically evaluate the CSS class to use.
+Following is an example of using dataset and JavaScript [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) to dynamically evaluate data attribute to use.
 
 ```yaml
   - entities:
@@ -278,7 +278,7 @@ Following is an example of using dataset and JavaScript [template literals](http
       service: floorplan.dataset_set
       service_data:
         key: motion
-        state: ${entity.state}
+        value: ${entity.state}
       #or alternatively
       service_data: 'motion:${entity.state}'
 ```

--- a/docs/_docs/03-usage.md
+++ b/docs/_docs/03-usage.md
@@ -235,7 +235,7 @@ Below are the services that are specific to Floorplan.
 | ----------------------------- | ------------------------------------------------ | ----------------------- |
 | `floorplan.class_toggle`      | Toggle a CSS class of the SVG element(s)         | `class` (string)        |
 | `floorplan.class_set`         | Set the CSS class of the SVG element(s)          | `class` (string)        |
-| `floorplan.class_prefixed_set`| Find a class with this prefix and set the value  | `prefix` (string)<br /> `value` (string) |
+| `floorplan.dataset_set`       | Set a data attribute of the SVG element(s)       | `key` (string)<br /> `value` (string) |
 | `floorplan.style_set`         | Set the CSS style of the of the SVG element(s)   | `style` (string)        |
 | `floorplan.text_set`          | Set the text of the SVG element(s)               | `text` (string)         |
 | `floorplan.image_set`         | Set the image of the SVG element(s)              | `image` (string)<br />`image_refresh_interval` (number)<br />`cache` (boolean) |
@@ -267,7 +267,7 @@ Below is an example of using JavaScript [template literals](https://developer.mo
         class: '${(entity.state === "on") ? "motion-on" : "motion-off"}'
 ```
 
-Following is an example of using prefixed classes and JavaScript [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) to dynamically evaluate the CSS class to use.
+Following is an example of using dataset and JavaScript [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) to dynamically evaluate the CSS class to use.
 
 ```yaml
   - entities:
@@ -275,12 +275,12 @@ Following is an example of using prefixed classes and JavaScript [template liter
       - binary_sensor.laundry
     state_action:
       action: call-service
-      service: floorplan.class_prefixed_set
+      service: floorplan.dataset_set
       service_data:
-        prefix: motion
+        key: motion
         state: ${entity.state}
       #or alternatively
-      service_data: 'motion-${entity.state}'
+      service_data: 'motion:${entity.state}'
 ```
 
 The following example shows how the style is generated using a block of JavaScript code that spans multiple lines.

--- a/docs/_docs/03-usage.md
+++ b/docs/_docs/03-usage.md
@@ -231,13 +231,15 @@ Floorplan supports calling all [services](https://www.home-assistant.io/docs/scr
 
 Below are the services that are specific to Floorplan.
 
-| Floorplan Service           | Description                                      | Service Data Properties |
-| --------------------------- | ------------------------------------------------ | ----------------------- |
-| `floorplan.class_toggle`    | Toggle a CSS class of the SVG element(s)         | `class` (string)        |
-| `floorplan.class_set`       | Set the CSS class of the SVG element(s)          | `class` (string)        |
-| `floorplan.style_set`       | Set the CSS style of the of the SVG element(s)   | `style` (string)        |
-| `floorplan.text_set`        | Set the text of the SVG element(s)               | `text` (string)         |
-| `floorplan.image_set`       | Set the image of the SVG element(s)              | `image` (string)<br />`image_refresh_interval` (number)<br />`cache` (boolean) |
+| Floorplan Service             | Description                                      | Service Data Properties |
+| ----------------------------- | ------------------------------------------------ | ----------------------- |
+| `floorplan.class_toggle`      | Toggle a CSS class of the SVG element(s)         | `class` (string)        |
+| `floorplan.class_set`         | Set the CSS class of the SVG element(s)          | `class` (string)        |
+| `floorplan.class_prefixed_set`| Find a class with this prefix and set the value  | `prefix` (string)<br /> `value` (string) |
+| `floorplan.style_set`         | Set the CSS style of the of the SVG element(s)   | `style` (string)        |
+| `floorplan.text_set`          | Set the text of the SVG element(s)               | `text` (string)         |
+| `floorplan.image_set`         | Set the image of the SVG element(s)              | `image` (string)<br />`image_refresh_interval` (number)<br />`cache` (boolean) |
+
 
 Service data can be dynamically constructed using JavaScript code. Below is the full set of objects that are available when writing code.
 
@@ -263,6 +265,22 @@ Below is an example of using JavaScript [template literals](https://developer.mo
       service: floorplan.class_set
       service_data:
         class: '${(entity.state === "on") ? "motion-on" : "motion-off"}'
+```
+
+Following is an example of using prefixed classes and JavaScript [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) to dynamically evaluate the CSS class to use.
+
+```yaml
+  - entities:
+      - binary_sensor.kitchen
+      - binary_sensor.laundry
+    state_action:
+      action: call-service
+      service: floorplan.class_prefixed_set
+      service_data:
+        prefix: motion
+        state: ${entity.state}
+      #or alternatively
+      service_data: 'motion-${entity.state}'
 ```
 
 The following example shows how the style is generated using a block of JavaScript code that spans multiple lines.

--- a/src/components/floorplan/floorplan-element.ts
+++ b/src/components/floorplan/floorplan-element.ts
@@ -90,9 +90,8 @@ export class FloorplanElement extends LitElement {
         <div id="floorplan"></div>
         
         <div id="log" style="display: ${this.isShowLog ? 'block' : 'none'};">
-          <a href="#" onclick="return false;" @click=${
-            this.clearLog
-          }>Clear log<a/>
+          <a href="#" onclick="return false;" @click=${this.clearLog
+      }>Clear log<a/>
           <ul></ul>
         </div>
       </div>
@@ -198,7 +197,7 @@ export class FloorplanElement extends LitElement {
   async hassChanged(): Promise<void> {
     if (!this.hass || !this.config || !this.svg) return; // wait for SVG to be loaded
 
-    var deviceId = Utils.deviceId();
+    const deviceId = Utils.deviceId();
 
     this.hass.states['*'] = {
       entity_id: `sensor.${deviceId}`,
@@ -348,9 +347,8 @@ export class FloorplanElement extends LitElement {
       script.onerror = (err) => {
         reject(
           new URIError(
-            `${
-              (err as unknown as Record<string, Record<string, unknown>>).target
-                .src
+            `${(err as unknown as Record<string, Record<string, unknown>>).target
+              .src
             }`
           )
         );
@@ -1025,7 +1023,7 @@ export class FloorplanElement extends LitElement {
           rule.hold_action === undefined
             ? defaultRule.hold_action
             : rule.hold_action;
-            
+
         rule.hover_info_filter =
           rule.hover_info_filter === undefined
             ? defaultRule.hover_info_filter
@@ -1263,13 +1261,13 @@ export class FloorplanElement extends LitElement {
 
         const singleTapContext = singleTapAction
           ? new FloorplanClickContext(
-              this,
-              entityId,
-              elementId,
-              svgElementInfo,
-              ruleInfo,
-              singleTapAction
-            )
+            this,
+            entityId,
+            elementId,
+            svgElementInfo,
+            ruleInfo,
+            singleTapAction
+          )
           : false;
 
         // Use simple function without delay, if doubleTap is not in use
@@ -1279,13 +1277,13 @@ export class FloorplanElement extends LitElement {
         if (doubleTapAction) {
           const doubleTapContext = doubleTapAction
             ? new FloorplanClickContext(
-                this,
-                entityId,
-                elementId,
-                svgElementInfo,
-                ruleInfo,
-                doubleTapAction
-              )
+              this,
+              entityId,
+              elementId,
+              svgElementInfo,
+              ruleInfo,
+              doubleTapAction
+            )
             : false;
 
           ManyClicks.observe(element as HTMLElement | SVGElement);
@@ -1497,12 +1495,12 @@ export class FloorplanElement extends LitElement {
       if (ruleInfo.rule.hover_action) {
         let isHoverInfo =
           typeof ruleInfo.rule.hover_action === 'string' &&
-          ruleInfo.rule.hover_action === 'hover-info'; 
+          ruleInfo.rule.hover_action === 'hover-info';
         isHoverInfo =
           isHoverInfo ||
           (typeof ruleInfo.rule.hover_action === 'object' &&
             (ruleInfo.rule.hover_action as FloorplanActionConfig).action ===
-              'hover-info');
+            'hover-info');
         isHoverInfo =
           isHoverInfo ||
           (Array.isArray(ruleInfo.rule.hover_action) &&
@@ -1534,10 +1532,9 @@ export class FloorplanElement extends LitElement {
                 titleText += `State: ${entityState.state}\n\n`;
 
                 Object.keys(entityState.attributes).map((key) => {
-                  if !(hoverInfoFilter.has(key)){
-                    titleText += `${key}: ${
-                      (entityState.attributes as Record<string, unknown>)[key]
-                    }\n`;
+                  if (!hoverInfoFilter.has(key)) {
+                    titleText += `${key}: ${(entityState.attributes as Record<string, unknown>)[key]
+                      }\n`;
                   }
                 });
                 titleText += '\n';
@@ -1707,7 +1704,7 @@ export class FloorplanElement extends LitElement {
         if (
           !confirm(
             actionConfig.confirmation.text ||
-              `Are you sure you want to ${actionConfig.action}?`
+            `Are you sure you want to ${actionConfig.action}?`
           )
         ) {
           return;
@@ -1744,7 +1741,7 @@ export class FloorplanElement extends LitElement {
               `Performing action: ${actionConfig.action} ${actionConfig.url_path}`
             );
           } else {
-            const open_type = actionConfig.same_tab ? '_self': '_blank';
+            const open_type = actionConfig.same_tab ? '_self' : '_blank';
             window.open(actionConfig.url_path, open_type);
           }
           break;
@@ -1977,6 +1974,42 @@ export class FloorplanElement extends LitElement {
               ? serviceData
               : (serviceData.class as string);
           Utils.setClass(targetSvgElement, className);
+        }
+        break;
+
+      case 'class_prefixed_set':
+        targetSvgElements = this.getSvgElementsFromServiceData(
+          serviceData,
+          svgElementInfo?.svgElement
+        );
+        for (const targetSvgElement of targetSvgElements) {
+          isSameTargetElement =
+            targetSvgElements.length === 1 &&
+            targetSvgElements[0] === svgElementInfo?.svgElement;
+          if (!isSameTargetElement) {
+            // Evaluate service data again, this time supplying 'target' element
+            serviceData = this.getServiceData(
+              actionConfig,
+              entityId,
+              targetSvgElement
+            );
+          }
+          let value: string;
+          let prefix: string;
+          if (typeof serviceData === 'string') {
+            const split = (serviceData as string).split('-');
+            if (split.length < 2) {
+              this.logError("FLOORPLAN_ACTION", `Service data "${serviceData}" is not a prefixed class.`)
+              break;
+            }
+            value = split.pop()!;
+            prefix = split.join('-');
+          }
+          else {
+            value = serviceData.value as string;
+            prefix = serviceData.prefix as string;
+          }
+          Utils.changePrefixedClassValue(targetSvgElement, prefix, value);
         }
         break;
 

--- a/src/components/floorplan/floorplan-element.ts
+++ b/src/components/floorplan/floorplan-element.ts
@@ -1977,42 +1977,43 @@ export class FloorplanElement extends LitElement {
         }
         break;
 
-      case 'class_prefixed_set':
-        targetSvgElements = this.getSvgElementsFromServiceData(
-          serviceData,
-          svgElementInfo?.svgElement
-        );
-        for (const targetSvgElement of targetSvgElements) {
-          isSameTargetElement =
-            targetSvgElements.length === 1 &&
-            targetSvgElements[0] === svgElementInfo?.svgElement;
-          if (!isSameTargetElement) {
-            // Evaluate service data again, this time supplying 'target' element
-            serviceData = this.getServiceData(
-              actionConfig,
-              entityId,
-              targetSvgElement
-            );
-          }
+      case 'dataset_set':
+        {
           let value: string;
-          let prefix: string;
+          let key: string;
           if (typeof serviceData === 'string') {
-            const split = (serviceData as string).split('-');
+            const split = (serviceData as string).split(':');
             if (split.length < 2) {
-              this.logError("FLOORPLAN_ACTION", `Service data "${serviceData}" is not a prefixed class.`)
+              this.logError("FLOORPLAN_ACTION", `Service data "${serviceData}" is not a valid dataset key value pair.`)
               break;
             }
-            value = split.pop()!;
-            prefix = split.join('-');
+            value = split[1];
+            key = split[0];
           }
           else {
             value = serviceData.value as string;
-            prefix = serviceData.prefix as string;
+            key = serviceData.key as string;
           }
-          Utils.changePrefixedClassValue(targetSvgElement, prefix, value);
+          targetSvgElements = this.getSvgElementsFromServiceData(
+            serviceData,
+            svgElementInfo?.svgElement
+          );
+          for (const targetSvgElement of targetSvgElements) {
+            isSameTargetElement =
+              targetSvgElements.length === 1 &&
+              targetSvgElements[0] === svgElementInfo?.svgElement;
+            if (!isSameTargetElement) {
+              // Evaluate service data again, this time supplying 'target' element
+              serviceData = this.getServiceData(
+                actionConfig,
+                entityId,
+                targetSvgElement
+              );
+            }
+            Utils.datasetSet(targetSvgElement, key, value);
+          }
+          break;
         }
-        break;
-
       case 'style_set':
         targetSvgElements = this.getSvgElementsFromServiceData(
           serviceData,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -15,12 +15,12 @@ export class Utils {
     element.classList
       ? element.classList.remove(className)
       : (element.className = element.className.replace(
-          new RegExp(
-            '(^|\\b)' + className.split(' ').join('|') + '(\\b|$)',
-            'gi'
-          ),
-          ' '
-        ));
+        new RegExp(
+          '(^|\\b)' + className.split(' ').join('|') + '(\\b|$)',
+          'gi'
+        ),
+        ' '
+      ));
   }
 
   static hassClass(element: Element, className: string): boolean {
@@ -40,6 +40,45 @@ export class Utils {
       this.removeClass(element, className);
     } else {
       this.addClass(element, className);
+    }
+  }
+
+  static changePrefixedClassValue(element: Element, prefix: string, value: string): void {
+    const currentClassValue = this.getPrefixedClass(element, prefix);
+    if (currentClassValue) {
+      this.replacePrefixedClassValue(element, currentClassValue, prefix, value);
+    }
+    else {
+      this.addClass(element, `${prefix}-${value}`);
+    }
+  }
+
+  static replacePrefixedClassValue(element: Element, prevValue: string, prefix: string, value: string): void {
+    if (element.classList) {
+      element.classList.replace(prevValue, `${prefix}-${value}`);
+    }
+    else {
+      element.className = element.className.replace(
+        new RegExp(
+          '(^|\\b)' + prevValue.split(' ').join('|') + '(\\b|$)',
+          'gi'
+        ),
+        `${prefix}-${value}`);
+    }
+  }
+
+  static getPrefixedClass(element: Element, prefix: string): string | undefined {
+    prefix = prefix + '-';
+    if (element.classList) {
+      for (const item of element.classList) {
+        if (item.includes(prefix)) {
+          return item;
+        }
+      }
+      return undefined;
+    }
+    else {
+      return new RegExp('(^| )' + `${prefix}-` + '( |$)', 'gi').exec(element.className)?.pop();
     }
   }
 
@@ -258,9 +297,8 @@ export class Utils {
   }
 
   static cacheBuster(url: string): string {
-    return `${url}${
-      url.indexOf('?') >= 0 ? '&' : '?'
-    }_=${new Date().getTime()}`;
+    return `${url}${url.indexOf('?') >= 0 ? '&' : '?'
+      }_=${new Date().getTime()}`;
   }
 
   static equal(a: unknown, b: unknown): boolean {
@@ -328,10 +366,9 @@ export class Utils {
   static deviceId(): string {
     const ID_BROWER_KEY = 'lovelace-ha-floorplan-device-id';
 
-    if(!localStorage[ID_BROWER_KEY])
-    {
+    if (!localStorage[ID_BROWER_KEY]) {
       const s4 = () => {
-        return Math.floor((1+Math.random())*100000).toString(16).substring(1);
+        return Math.floor((1 + Math.random()) * 100000).toString(16).substring(1);
       }
       localStorage[ID_BROWER_KEY] = `${s4()}${s4()}-${s4()}${s4()}`;
     }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -43,43 +43,8 @@ export class Utils {
     }
   }
 
-  static changePrefixedClassValue(element: Element, prefix: string, value: string): void {
-    const currentClassValue = this.getPrefixedClass(element, prefix);
-    if (currentClassValue) {
-      this.replacePrefixedClassValue(element, currentClassValue, prefix, value);
-    }
-    else {
-      this.addClass(element, `${prefix}-${value}`);
-    }
-  }
-
-  static replacePrefixedClassValue(element: Element, prevValue: string, prefix: string, value: string): void {
-    if (element.classList) {
-      element.classList.replace(prevValue, `${prefix}-${value}`);
-    }
-    else {
-      element.className = element.className.replace(
-        new RegExp(
-          '(^|\\b)' + prevValue.split(' ').join('|') + '(\\b|$)',
-          'gi'
-        ),
-        `${prefix}-${value}`);
-    }
-  }
-
-  static getPrefixedClass(element: Element, prefix: string): string | undefined {
-    prefix = prefix + '-';
-    if (element.classList) {
-      for (const item of element.classList) {
-        if (item.includes(prefix)) {
-          return item;
-        }
-      }
-      return undefined;
-    }
-    else {
-      return new RegExp('(^| )' + `${prefix}-` + '( |$)', 'gi').exec(element.className)?.pop();
-    }
+  static datasetSet(element: SVGGraphicsElement | HTMLElement, key: string, value: string): void {
+    element.dataset[key] = value;
   }
 
   static getStyles(


### PR DESCRIPTION
Based on the request in #179 added a new floorplan service called class_prefixed_set.
The way it works:
Say we have a prefix **ha-light-state** and the entity state is **on**, this will generate a class **ha-light-state-on**.
If the state changes to off, the service will look at current classes on the element and will try to find a class that matches the prefix (the match it will perform will be **ha-light-state-**).
If it finds multiple matches it will take the last one, which could be undesirable, but it's up to the user to make sure the class prefix for this element is unique.
If the class with such prefix is found, it will be changed to **ha-light-state-off**
If the class does not exist, the class will be added.