### PR TITLE
Update floorplan-element.ts

### DIFF
--- a/src/components/floorplan/floorplan-element.ts
+++ b/src/components/floorplan/floorplan-element.ts
@@ -397,6 +397,8 @@ export class FloorplanElement extends LitElement {
     for (const pageInfo of nonMasterPages) {
       await this.loadPageFloorplanSvg(pageInfo, masterPageInfo);
     }
+    
+    this.svg = masterPageInfo.svg;
   }
 
   async loadPageConfig(


### PR DESCRIPTION
[BUGFIX] Function hassChanged did not started when using MultiPages.

When using MultiPages floorplan stops receving state changes.

I trace what happend and found that this.svg is undefined if used multiple pages.

```
async hassChanged(): Promise<void> {
    if (!this.hass || !this.config || !this.svg) return; // wait for SVG to be loaded
```
