### PR TITLE
Fix duplicated SVG element on config update

### DIFF
--- a/src/components/floorplan/floorplan-element.ts
+++ b/src/components/floorplan/floorplan-element.ts
@@ -588,7 +588,7 @@ export class FloorplanElement extends LitElement {
         masterPageInfo.config.master_page.content_element;
 
       if (pageInfo.config.page_id === masterPageId) {
-        this.floorplanElement.appendChild(svg);
+        this.floorplanElement.replaceChildren(svg);
       } else {
         // const masterPageElement = this.floorplanElement.querySelector('#' + masterPageId);
         const contentElement = this.floorplanElement.querySelector(
@@ -613,10 +613,10 @@ export class FloorplanElement extends LitElement {
         svg.setAttribute('x', contentElement.getAttribute('x') as string);
         svg.setAttribute('y', contentElement.getAttribute('y') as string);
 
-        contentElement.parentElement?.appendChild(svg);
+        contentElement.parentElement?.replaceChildren(svg);
       }
     } else {
-      this.floorplanElement.appendChild(svg);
+      this.floorplanElement.replaceChildren(svg);
     }
 
     // TODO: Re-enable???


### PR DESCRIPTION
Fixing #268 

It looks like the SVG element is always appended to the container but the container is never cleared. It results with new SVG added on every config update. It is very easy to repro when you add the card via UI to Lovelace dashboard.