### PR TITLE
Feat/support important in set style

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -79,7 +79,9 @@ export class Utils {
 
     for (let i = 0; i < styles.length; i++) {
       const parts = styles[i].split(':').map((x) => x.trim());
-      element.style.setProperty(parts[0], parts[1]);
+      const isImportant = parts[1].includes('!important');
+      parts[1] = parts[1].replace(/!important/g, '').trim();
+      element.style.setProperty(parts[0], parts[1], isImportant ? 'important' : '');
     }
   }
 


### PR DESCRIPTION
Implement support of `!important` in `style_set` so it's possible to set something like `fill:red!important`, even though you've used "!important" in your CSS file.

I don't really recommend the use of "important", but while testing something else, I spotted the lack of that.