### PR TITLE
Do not add * as target

### DIFF
--- a/src/components/floorplan/floorplan-element.ts
+++ b/src/components/floorplan/floorplan-element.ts
@@ -1179,6 +1179,10 @@ export class FloorplanElement extends LitElement {
           this.evaluate(rule.element, entityId, undefined) as string
         );
       else if (rule.element !== null) elementIds = elementIds.concat(entityId);
+      
+      // Do not add target entity "*"
+      if (entityId && entityId === "*") continue;
+
       this.addTargetEntity(entityId, elementIds, targetEntities);
     }
 


### PR DESCRIPTION
Let's get rid of the `WARNING CONFIG Cannot find '*' in Home Assistant entities` message in the demo (and HA, ofc)

<img width="1122" alt="image" src="https://github.com/user-attachments/assets/f8d0d7ee-5cab-48a5-9ed6-00aa5c484475">
