### PR TITLE
Remove zip_release key as that's only supported by integrations

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -2,6 +2,5 @@
   "name": "ha-floorplan 🖌🎨 | Your imagination (almost) defines the limits",
   "filename": "floorplan.js",
   "render_readme": true,
-  "homeassistant": "2024.6.0",
-  "zip_release": true
+  "homeassistant": "2024.6.0"
 }


### PR DESCRIPTION
Remove zip_release key as that's only supported by integrations. Right now, HACS are unable to download the content