### PR TITLE
feature: expose page-local root SVG element as global  in rule scripts

### DIFF
--- a/docs/_docs/03-usage.md
+++ b/docs/_docs/03-usage.md
@@ -253,6 +253,7 @@ Service data can be dynamically constructed using JavaScript code. Below is the 
 | `hass`                   | Home Assistant [hass](https://home-assistant.io/developers/development_hass_object/) object |
 | `element`                | current SVG element                                                                         |
 | `elements`               | current SVG elements                                                                        |
+| `svg`                    | Root `<svg>` element for the current floorplan page (use for scoped `querySelector(...)`)   |
 
 | Functions                | Description                                                                                 |
 | ------------------------ | ------------------------------------------------------------------------------------------- |

--- a/src/components/floorplan/floorplan-element.ts
+++ b/src/components/floorplan/floorplan-element.ts
@@ -1715,6 +1715,7 @@ export class FloorplanElement extends LitElement {
           this.svgElements,
           this.functions,
           svgElementInfo,
+          this.svg,
           ruleInfo
         );
       } catch (err) {

--- a/src/components/floorplan/lib/eval-helper.ts
+++ b/src/components/floorplan/lib/eval-helper.ts
@@ -45,6 +45,7 @@ export class EvalHelper {
     svgElements?: { [elementId: string]: SVGGraphicsElement },
     functions?: unknown,
     svgElementInfo?: FloorplanSvgElementInfo,
+    svg?: SVGGraphicsElement,
     ruleInfo?: FloorplanRuleInfo
   ): unknown {
     this.expression = expression.trim();
@@ -97,6 +98,7 @@ export class EvalHelper {
     this.interpreter.import('hass', hass);
     this.interpreter.import('element', svgElement);
     this.interpreter.import('elements', svgElements);
+    this.interpreter.import('svg', svg); // Provide direct access to the root <svg> element for rule scripts
 
     // Let the user call "action" function (to call our service call-handler)
     this.interpreter.import('action',


### PR DESCRIPTION
This PR exposes the page-local `<svg>` element as a global variable `svg` inside rule scripts.

### Why?
In many cases, it's necessary to access and manipulate SVG elements programmatically — especially when:

* The elements can't be grouped cleanly (e.g., interleaved geometry)
* They lack unique IDs
* The rule doesn't target a specific item directly

Currently, this requires traversing the DOM manually to locate the correct shadow root and extract the right <svg> element, which is error-prone in multi-page setups and often results in dozens of lines of utility code. It's easy to accidentally target another view’s SVG, leading to subtle bugs.

This change injects the page-local `<svg>` element as a scoped svg variable into the script execution context, making it directly and safely accessible from within rules. This greatly simplifies common patterns like:

```js
const zone = svg.querySelector('[data-mesh-id="zone.kitchen"]');
```

and removes the need for custom DOM discovery logic typically injected via startup_action. There may be other ways to achieve this that I’ve overlooked, but this approach has worked very well for me in practice.
