### PR TITLE
Add support for wildcard entity IDs

### DIFF
--- a/docs/_docs/03-usage.md
+++ b/docs/_docs/03-usage.md
@@ -185,6 +185,8 @@ The following types of items can be used as subjects within a rule.
 
 The special case `entity: '*'` represents all HA entities. It can be used in rules that need to run whenever the state of any HA entity changes.
 
+Wildcards (*) can also be used to match subsets of entities, for example `light.*`, `sensor.*_temperature`.
+
 ### Action Triggers
 
 Floorplan supports the same action triggers used in [Lovelace](https://www.home-assistant.io/lovelace/actions) (`tap_action`, `hold_action`, `double_tap_action`). In addition to these, Floorplan adds two of its own action triggers.


### PR DESCRIPTION
This diff adds the option to use wildcards to specify entity rules. This can save a lot of typing and need to manually update rule files when adding additional entities to the system.

**Examples**

Light Rule:
```yaml
        - entity: light.*
```

Temperature Visualization Rule:
```yaml
        - entity: sensor.*_temperature
```

Door State Visualization:
```yaml
        - entities:
            - binary_sensor.*_door
            - lock.*_door
```