### PR TITLE
Added card_set service to set / reset card inside SVG by using foreignObject tag

### DIFF
--- a/docs/_docs/03-usage.md
+++ b/docs/_docs/03-usage.md
@@ -241,6 +241,7 @@ Below are the services that are specific to Floorplan.
 | `floorplan.style_set`    | Set the CSS style of the of the SVG element(s) | `style` (string)                                                               |
 | `floorplan.text_set`     | Set the text of the SVG element(s)             | `text` (string)<br />`shift_y_axis: 2em`                                                               |
 | `floorplan.image_set`    | Set the image of the SVG element(s)            | `image` (string)<br />`image_refresh_interval` (number)<br />`cache` (boolean) |
+| `floorplan.card_set`     | Set HA card of a SVG foreignObject element     | `container_id` (string)<br />`config` (array, optional)                                                               |
 | `floorplan.execute`      | Execute your own JS, defined in service_data   | `<all>` (array)                                                                |
 
 Service data can be dynamically constructed using JavaScript code. Below is the full set of helpers, that are available when writing code.
@@ -344,6 +345,66 @@ The following example shows how the style is generated using a block of JavaScri
         var height = Math.ceil(elements['sensor.moisture_level'].getBBox().height);
         return `transform: translate(0, ${height - Math.floor(entity.attributes.level / (100 / height))}px)`;
 ```
+
+#### Using `card_set` to set / reset / change a HA card inside a foreignObject tag
+
+If you want to embed HA card in your SVG, add a foreignObject tag inside your SVG, like this example :
+
+```svg
+...
+<foreignObject id="CardContainer" x="700" y="600" width="400" height="200"></foreignObject>
+...
+
+Then you can use card_set to set (change in case of card already set before) a HA card, here is an example with the map card :
+
+```yaml
+- entity:
+    - binary_sensor.garage
+  state_action:
+    action: call-service
+    service: floorplan.card_set
+    service_data:
+      container_id: CardContainer
+      config:
+        type: map
+        entities:
+          - zone.home
+        aspect_ratio: "2"
+```
+
+In the config, you must specify the type of the card you want (here type: map), you can use a custom card with custom: prefix (type: custom:mycustomcard).
+Then you can specify the configuration of this card directly in config, as you normally do in the yaml configuration.
+
+If you want to remove a card already set before, you can also use card_set but without config, like this example :
+
+```yaml
+- element:
+    - MyButton
+  tap_action:
+    action: call-service
+    service: floorplan.card_set
+    service_data:
+      container_id: CardContainer
+```
+
+You can also specify multiple cards at once with an array :
+
+```yaml
+- element:
+    - MyButton
+  tap_action:
+    action: call-service
+    service: floorplan.card_set
+    service_data:
+      - container_id: CardContainer
+      - container_id: CardContainer2
+        config:
+          type: weather-forecast
+          entity: weather.forecast_maison
+          forecast_type: daily
+```
+
+In this example, when MyButton receives a tap, the card in CardContainer is removed and the CardContainer2 receives the card weather-forecast.
 
 #### Using `execute` with browser_mod
 

--- a/docs/_docs/03-usage.md
+++ b/docs/_docs/03-usage.md
@@ -350,10 +350,9 @@ The following example shows how the style is generated using a block of JavaScri
 
 If you want to embed HA card in your SVG, add a foreignObject tag inside your SVG, like this example :
 
-```svg
-...
+```html
 <foreignObject id="CardContainer" x="700" y="600" width="400" height="200"></foreignObject>
-...
+```
 
 Then you can use card_set to set (change in case of card already set before) a HA card, here is an example with the map card :
 

--- a/docs/_docs/floorplan/examples/test_plate/test_plate.svg
+++ b/docs/_docs/floorplan/examples/test_plate/test_plate.svg
@@ -305,5 +305,8 @@
        id="tspan2"
        style="font-size:4px;stroke-width:0.264583"
        x="22.885237"
-       y="21.933382">Click to hide radar</tspan></text></g>
+       y="21.933382">Click to hide radar</tspan></text>
+	   <foreignObject id="CardContainer1" x="500" y="300" width="200" height="100"></foreignObject>
+	   <foreignObject id="CardContainer2" x="500" y="400" width="100" height="100"></foreignObject>
+	   </g>
        </svg>

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -20,6 +20,24 @@ global.VERSION = packageJson.version;
 let examples_server;
 
 beforeAll(() => {
+  global.window = global;
+  window.customElements = window.customElements || {
+    define: jest.fn(),
+    get: jest.fn(),
+  };
+  
+  window.loadCardHelpers = jest.fn().mockResolvedValue({
+    createCardElement: jest.fn().mockImplementation((config) => {
+      const card = document.createElement("ha-card");
+
+      card.config = config;
+      card.hass = null;
+      card.updateComplete = Promise.resolve();
+      
+      return card;
+    }),
+  });
+
   // Mock getBBox for SVG elements
   Object.defineProperty(SVGElement.prototype, 'getBBox', {
     value: jest.fn().mockReturnValue({

--- a/src/components/floorplan/floorplan-element.ts
+++ b/src/components/floorplan/floorplan-element.ts
@@ -901,7 +901,7 @@ export class FloorplanElement extends LitElement {
       let container = this.shadowRoot?.querySelector("#" + containerId);
       if (!container) {
         this.logError(
-          'CONFIG',//TODO: ca ou FLOORPLAN_ACTION ?
+          'CONFIG',
           `Cannot find element '${containerId}' in SVG file`
         );
         return;


### PR DESCRIPTION
Added the card_set service which can be used like that :

```
startup_action:                                  <- Here it is called at startup but you can call the service on a normal tap_action or other actions
  - action: call-service
     service: floorplan.card_set                 <- The new service
     service_data:
       container_id: CardContainer               <- The ID of the foreignObject tag inside your SVG
       config:                                   <- If you put this, you will set a card inside foreignObject tag, if you don't, you remove any card that may be in foreignObject
         type: map                               <- The type of the card you want to set (mandatory)
         entities:                               <- All that follows is the config for the card (here the config for the map card)
            - zone.home
          aspect_ratio: "2"

service_data:
  - container_id: CardContainer                  <- You can also set multiple cards at once by using array
     config:
       type: map
       entities:
         - zone.home
       aspect_ratio: "2"
  - container_id: CardContainer2
     config:
       type: weather-forecast
       entity: weather.forecast_maison
       forecast_type: daily

Example of a foreignObject tag inside a SVG file :

<foreignObject id="CardContainer" x="996" y="920" width="484" height="242"></foreignObject>

```

Why this feature ?

Of course, you can add a card normally and use CSS to move card above the SVG but there are at least two caveats :
- The relative position is hard to keep correct when resizing
- In case of a floorplan used as a main card inside a custom ha-dashboard, you can have only one card