### PR TITLE
Add read-permission to hacs validate-job

### DIFF
--- a/.github/workflows/hacs-validation.yaml
+++ b/.github/workflows/hacs-validation.yaml
@@ -11,6 +11,8 @@ on:
 jobs:
   validate:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: HACS validation


### PR DESCRIPTION
Fixes hacs validation issues in master-branch, currently throwing:

```
Error:  401
Error:  Repository ExperienceLovelace/ha-floorplan not loaded properly in HACS.
```